### PR TITLE
Give a longer timeout to the downloader

### DIFF
--- a/lib/npm_deps.ex
+++ b/lib/npm_deps.ex
@@ -11,7 +11,7 @@ defmodule NpmDeps do
     Logger.info("Downloading NPM packages...")
 
     deps
-    |> Task.async_stream(fn {name, version} -> get(name, version) end)
+    |> Task.async_stream(fn {name, version} -> get(name, version) end, timeout: 60_000)
     |> Enum.each(fn {:ok, {:ok, {name, version}}} ->
       Logger.info("Downloaded #{name} #{version}")
     end)


### PR DESCRIPTION
I found five seconds insufficient to download the packages I was using (admittedly, Bootstrap and Highlight.js). This extends the timeout to a full minute, which I chose entirely arbitrarily and did not measure for at all, but it certainly lets me use this successfully.